### PR TITLE
Fixed 2 issues

### DIFF
--- a/src/CameraGigeAravis.cpp
+++ b/src/CameraGigeAravis.cpp
@@ -563,9 +563,8 @@
 
         arv_camera_get_gain_bounds (camera, &gainMin, &gainMax);
 
-		// Uncomment this line if one want to force the Frame Rate at a given value
-		// otherwise the value from the configuration file is used.
-        // arv_camera_set_frame_rate(camera, 1);
+		// Set the required Frame Rate obtained from the configuration file
+        arv_camera_set_frame_rate(camera, frame.mFps);
 
         fps = arv_camera_get_frame_rate(camera);
 

--- a/src/CameraGigeAravis.cpp
+++ b/src/CameraGigeAravis.cpp
@@ -224,7 +224,9 @@
         BOOST_LOG_SEV(logger, notification) << "Camera gain bound min : " << gainMin;
         BOOST_LOG_SEV(logger, notification) << "Camera gain bound max : " << gainMax;
 
-        arv_camera_set_frame_rate(camera, 30);
+		// Uncomment this line if one want to force the Frame Rate at a given value
+		// otherwise the value from the configuration file is used.
+        // arv_camera_set_frame_rate(camera, 30);
 
         fps = arv_camera_get_frame_rate(camera);
         BOOST_LOG_SEV(logger, notification) << "Camera frame rate : " << fps;
@@ -561,7 +563,9 @@
 
         arv_camera_get_gain_bounds (camera, &gainMin, &gainMax);
 
-        arv_camera_set_frame_rate(camera, 1);
+		// Uncomment this line if one want to force the Frame Rate at a given value
+		// otherwise the value from the configuration file is used.
+        // arv_camera_set_frame_rate(camera, 1);
 
         fps = arv_camera_get_frame_rate(camera);
 

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -565,6 +565,17 @@ bool Device::setCameraFPS() {
 
 }
 
+/* Method to set the camera FPS at a given value */
+bool Device::setCameraFPS(double value) {
+
+    if(!mCam->setFPS(value)) {
+        BOOST_LOG_SEV(logger, fail) << "Fail to set FPS to " << value;
+        mCam->grabCleanse();
+        return false;
+    }
+    return true;
+}
+
 bool Device::initializeCamera() {
 
     if(!mCam->grabInitialization()){

--- a/src/Device.h
+++ b/src/Device.h
@@ -192,6 +192,8 @@ class Device {
 
         bool setCameraFPS();
 
+        bool setCameraFPS(double value);
+ 
         bool setCameraSize();
 
         bool getCameraFPS(double &fps);

--- a/src/Device.h
+++ b/src/Device.h
@@ -113,7 +113,7 @@ class Device {
         int         mNightGain;
         int         mDayExposure;
         int         mDayGain;
-        int         mFPS;
+        double      mFPS;
         int         mCamID;         // ID in a specific sdk.
         int         mGenCamID;      // General ID.
         Camera      *mCam;

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -59,7 +59,7 @@ class Frame {
         int                 mFrameNumber;        // Each frame is identified by a number corresponding to the acquisition order.
         int                 mFrameRemaining;     // Define the number of remaining frames if the input source is a video or a set of single frames.
         double              mSaturatedValue;     // Max pixel value in the image.
-        int                 mFps;                // Camera's fps.
+        double              mFps;                // Camera's fps.
         int                 mWidth;
         int                 mHeight;
 

--- a/src/SParam.h
+++ b/src/SParam.h
@@ -136,7 +136,7 @@ struct scheduleParam {
 // ******************************************************
 
 struct cameraParam{
-    int         ACQ_FPS;
+    double      ACQ_FPS;
     CamPixFmt   ACQ_FORMAT;
     bool        ACQ_RES_CUSTOM_SIZE;
     bool        SHIFT_BITS;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -376,7 +376,8 @@ int main(int argc, const char ** argv){
                             delete device;
                             throw "Fail to set format";
                         }
-                        device->setCameraFPS();
+                        // Set the FPS specifically to the value provided in the configuration file
+                        device->setCameraFPS((cfg.getCamParam().ACQ_FPS);
                         device->setCameraExposureTime(exp);
                         device->setCameraGain(gain);
                         device->initializeCamera();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -377,7 +377,7 @@ int main(int argc, const char ** argv){
                             throw "Fail to set format";
                         }
                         // Set the FPS specifically to the value provided in the configuration file
-                        device->setCameraFPS((cfg.getCamParam().ACQ_FPS);
+                        device->setCameraFPS(cfg.getCamParam().ACQ_FPS);
                         device->setCameraExposureTime(exp);
                         device->setCameraGain(gain);
                         device->initializeCamera();
@@ -811,6 +811,8 @@ int main(int argc, const char ** argv){
                         frame.mFormat = static_cast<CamPixFmt>(acqFormat);
                         frame.mHeight = acqHeight;
                         frame.mWidth = acqWidth;
+                        // Set the FPS specifically to the value provided in the configuration file
+                        frame.mFps = cfg.getCamParam().ACQ_FPS;
 
                         Device *device = new Device();
                         device->listDevices(false);


### PR DESCRIPTION
- Changed ACQ_FPS type from int to double in order to accomodate non integer frame rate values.
- Code has been modified to take into account the ACQ_FPS parameter from the configuration file. Up to now, a frame rate of 30 was forced for
  modes 2 and 3.
