### PR TITLE
Gige Aravis: Enforcing 30 fps is not a good idea

### DIFF
--- a/src/AcqThread.cpp
+++ b/src/AcqThread.cpp
@@ -1161,12 +1161,12 @@ bool AcqThread::prepareAcquisitionOnDevice() {
 
     }
 
-    // SET FPS.
-    if(!mDevice->setCameraFPS())
-        return false;
-
     // INIT CAMERA.
     if(!mDevice->initializeCamera())
+        return false;
+
+    // SET FPS.
+    if(!mDevice->setCameraFPS())
         return false;
 
     // START CAMERA.


### PR DESCRIPTION
INIT means to reset, thus changing FPS shall follow initialization not vice versa.
